### PR TITLE
fix!: verify Sixgill TLS certificates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/phantomcyber/dev-cicd-tools
+    rev: v2.2.4
+    hooks:
+      - id: package-app-dependencies
+        language: python
+        additional_dependencies: ["local-hooks"]
+      - id: static-tests
+        language: python
+        additional_dependencies: ["local-hooks"]
+        args: ['.']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--no-verify', '--exclude-files', '^sixgilldarkfeed.json$']

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,0 +1,3 @@
+**Unreleased**
+
+* Verify TLS certificates when communicating with Cybersixgill by default.

--- a/sixgill_on_poll_connector.py
+++ b/sixgill_on_poll_connector.py
@@ -98,6 +98,7 @@ class SixgillOnPollConnector(object):
                 self._sixgill_phantom_channel_id,
                 FeedStream.DARKFEED,
                 bulk_size=self._limit,
+                verify=self._verify_ssl,
             )
             indicator_object = darkfeed_client.get_bundle().get("objects")
         except Exception as e:

--- a/sixgill_test_connectivity_connector.py
+++ b/sixgill_test_connectivity_connector.py
@@ -24,13 +24,17 @@ class SixgillTestConnectivityConnector(object):
         config = connector.get_config()
         self._sixgill_client_id = config[SIXGILL_API_ID_CFG]
         self._sixgill_api_secret_key = config[SIXGILL_API_SECRET_KEY_CFG]
+        self._verify_ssl = config[SIXGILL_VERIFY_SSL]
         self._sixgill_phantom_channel_id = SIXGILL_CHANNEL_ID
 
     def test_connectivity(self):
         action_result = self._connector.add_action_result(ActionResult(dict()))
         self._connector.save_progress(SIXGILL_TEST_CONNECTIVITY_MSG)
         sixgill_valid_credentials = SixgillBaseClient(
-            self._sixgill_client_id, self._sixgill_api_secret_key, self._sixgill_phantom_channel_id
+            self._sixgill_client_id,
+            self._sixgill_api_secret_key,
+            self._sixgill_phantom_channel_id,
+            verify=self._verify_ssl,
         )
         try:
             if sixgill_valid_credentials._get_access_token():

--- a/sixgilldarkfeed.json
+++ b/sixgilldarkfeed.json
@@ -47,7 +47,7 @@
         "verify_ssl": {
             "description": "Verify SSL Certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 3
         }
     },

--- a/sixgilldarkfeed_consts.py
+++ b/sixgilldarkfeed_consts.py
@@ -6,7 +6,7 @@
 
 
 SIXGILL_API_ID_CFG = "sixgill_client_id"
-SIXGILL_API_SECRET_KEY_CFG = "sixgill_client_secret_key"
+SIXGILL_API_SECRET_KEY_CFG = "sixgill_client_secret_key"  # pragma: allowlist secret
 SIXGILL_VERIFY_SSL = "verify_ssl"
 AUTH_TOKEN = "phantom_auth_token"
 SIXGILL_CHANNEL_ID = "d6803eff87582a695d5630f1a52152bf"


### PR DESCRIPTION
### Bug Fixes

- PSAAS-31407: new Sixgill Darkfeed assets verify TLS certificates by default. The existing asset setting is now passed to both bundled Cybersixgill API clients used by test connectivity and ingestion.

### Manual Documentation

- [x] No `manual_readme_content.md` update is needed; this changes an existing asset setting default.

### Other information

- Root cause: the bundled Sixgill clients default their `verify` parameter to `False`, and the connector did not pass its existing setting to those client calls.
- This is a breaking secure-default change; existing assets can retain an explicit opt-out where required.
- Tracking: PAPP-38101; PSAAS-31407 (VULN-94132 / FS-2289 provenance).
- Validated with JSON parsing, Python compilation, SDK-constructor inspection, `pre-commit run --all-files`, and `git diff --check`.

Written by Codex.