### PR TITLE
fix: add Sixgill release README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Sixgill Darkfeed
+
+Connector Version: 1.0.1
+
+This connector integrates Splunk SOAR with Sixgill Darkfeed.


### PR DESCRIPTION
## Summary

Add the connector README required by the shared semantic-release version updater.

## Root cause

The post-merge release job copies and runs `update_version.py`, which exits when `README.md` is absent. This caused the semantic-version job to fail before publishing version 2.0.0.

## Validation

- Ran the copied release updater with `2.0.0`; it updated the app metadata and generated release notes successfully.
- Ran `pre-commit run --all-files` before the dependency refresh attempt: static tests and detect-secrets passed; the package-dependencies hook had no applicable files.
- `git diff --check` passed.

Authored by Codex.
